### PR TITLE
Support a namespace for all published dirs

### DIFF
--- a/connect-publish/README.md
+++ b/connect-publish/README.md
@@ -49,6 +49,32 @@ When not specified, the RStudio Connect server configuration
 default applies. Access types disallowed by RStudio Connect server
 configuration will result in the publish being canceled.
 
+### `namespace`
+
+Namespace prefix for published paths. (No default)
+
+This value is used in the construction of the "vanity URL" path,
+e.g. this configuration:
+
+```yaml
+  - uses: rstudio/actions/connect-publish@main
+    with:
+      url: https://${{ secrets.RSTUDIO_CONNECT_API_KEY }}@connect.example.org
+      namespace: experimental-beta
+      dir: ./very-shiny-app/:/shiny/app/path/
+```
+
+will result in a published URL of
+
+```
+https://connect.example.org/experimental-beta/shiny/app/path/
+```
+
+> **NOTE** Because the namespace is used as the first segment of a
+> slash-delimited path, there are restrictions on what is allowed
+> by RStudio Connect. For example, a namespace of `connect` is not
+> allowed and will result in an error at publish time.
+
 ### `show-logs`
 
 Show all publishing logs. (Default `false`)

--- a/connect-publish/__tests__/connect-publish.test.ts
+++ b/connect-publish/__tests__/connect-publish.test.ts
@@ -29,6 +29,7 @@ describe("connectPublish", () => {
     },
     {
       dir: 'testapps/flask',
+      ns: 'sneaky',
       expectError: false
     },
     {
@@ -40,6 +41,9 @@ describe("connectPublish", () => {
   testCases.forEach((tc: any) => {
     it(`publishes ${tc.dir} to connect`, async () => {
       process.env["INPUT_DIR"] = tc.dir
+      if (tc.ns !== undefined) {
+        process.env["INPUT_NAMESPACE"] = tc.ns
+      }
       const results = await connectPublish(loadArgs())
         .catch((err: any) => {
           if (tc.expectError) {

--- a/connect-publish/action.yml
+++ b/connect-publish/action.yml
@@ -12,6 +12,8 @@ inputs:
   force:
     description: Force publish even if up to date
     default: false
+  namespace:
+    description: Namespace prefix for published paths
   show-logs:
     description: Show all publishing logs
     default: false


### PR DESCRIPTION
such as when using the action in both pull requests and pushes, both targeting the same RStudio Connect URL, and not wanting to clobber publishes in either direction.