### PR TITLE
Add support for `working-directory` arg in connect-publish action

### DIFF
--- a/connect-publish/action.yml
+++ b/connect-publish/action.yml
@@ -25,6 +25,9 @@ inputs:
     default: true
   url:
     description: RStudio Connect URL
+  working-directory:
+    description: Directory relative to which the 'dir' argument(s) will be resolved
+    default: .
 runs:
   using: node16
   main: dist/index.js

--- a/connect-publish/src/connect-publish.ts
+++ b/connect-publish/src/connect-publish.ts
@@ -30,6 +30,7 @@ export interface ActionArgs {
   showLogs: boolean
   updateEnv: boolean
   url: string
+  workingDirectory: string
 }
 
 interface publishArgs {
@@ -76,7 +77,9 @@ export async function connectPublish (args: ActionArgs): Promise<ConnectPublishR
   const client = new rsconnect.APIClient({ apiKey: args.apiKey, baseURL })
   await client.serverSettings()
 
-  const { accessType, dirs, force, ns, requireVanityPath, showLogs, updateEnv } = args
+  const { accessType, dirs, force, ns, requireVanityPath, showLogs, updateEnv, workingDirectory } = args
+
+  process.chdir(workingDirectory)
 
   return await publishFromDirs({
     accessType, client, dirs, force, ns, requireVanityPath, showLogs, updateEnv
@@ -302,6 +305,8 @@ export function loadArgs (): ActionArgs {
   url.password = ''
   url.username = ''
 
+  const workingDirectory = core.getInput('working-directory')
+
   const dirs = core.getInput('dir').split('\n').map(s => s.trim()).filter(s => s !== '')
   if (dirs.length === 0) {
     dirs.push('.')
@@ -334,7 +339,8 @@ export function loadArgs (): ActionArgs {
     requireVanityPath,
     showLogs,
     updateEnv,
-    url: url.toString()
+    url: url.toString(),
+    workingDirectory
   }
 }
 


### PR DESCRIPTION
so that a base directory _other than_ the current working directory may be used when resolving entries in the `dir` argument. The name `working-directory` was chosen based on the same name used for the builtin `run` step in github actions.

ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun