### PR TITLE
update connect-publish action to use node20

### DIFF
--- a/connect-publish/action.yml
+++ b/connect-publish/action.yml
@@ -29,5 +29,5 @@ inputs:
     description: Directory relative to which the 'dir' argument(s) will be resolved
     default: .
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
I see warnings from GitHub Actions about node16 being deprecated when I use the connect-publish action. I'd like to quiet those warnings.