### PR TITLE
Document `working-directory` input in `connect-publish` action

### DIFF
--- a/connect-publish/README.md
+++ b/connect-publish/README.md
@@ -49,7 +49,7 @@ content. (Default `"."`)
 
 ### `working-directory`
 
-Directory relative to which the 'dir' argument(s) will be resolved.
+Directory relative to which the 'dir' argument(s) will be resolved. (Default `"."`).
 
 ### `api-key`
 

--- a/connect-publish/README.md
+++ b/connect-publish/README.md
@@ -47,6 +47,10 @@ content. (Default `"."`)
 > - vanity URL (path), e.g. `/name-with/a-slash`, which is tried
 >   when the string *does* contain at least one slash
 
+### `working-directory`
+
+Directory relative to which the 'dir' argument(s) will be resolved.
+
 ### `api-key`
 
 An [API key genereted in RStudio


### PR DESCRIPTION
This input has been valid since #32 , but was not documented.