### PR TITLE
feat: upgrade @rstudio/rsconnect-ts to v0.8.0

### DIFF
--- a/connect-publish/package-lock.json
+++ b/connect-publish/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
-        "@rstudio/rsconnect-ts": "^0.7.0",
+        "@rstudio/rsconnect-ts": "^0.8.0",
         "ansi-styles": "^6.2.1"
       },
       "devDependencies": {
@@ -2537,9 +2537,10 @@
       }
     },
     "node_modules/@rstudio/rsconnect-ts": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@rstudio/rsconnect-ts/-/rsconnect-ts-0.7.0.tgz",
-      "integrity": "sha512-yDWUvLG1tdRqWDXF7VMWB4sv6AtOSbDlSyX9hjDNdU/JDDhxvz7zVa4f7Ton4hLZvyax5JzkhiENcuVTkSYmpg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@rstudio/rsconnect-ts/-/rsconnect-ts-0.8.0.tgz",
+      "integrity": "sha512-2J0CyTQEKySUpR2nWxr4yaBH7rV5dV2Mr4aZ9hKi7jIV2v6LySX53QHLMFaXMx+9Iir/orcJAXKIqRCUqORgVw==",
+      "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.5",
         "@types/qs": "^6.9.15",
@@ -11086,9 +11087,9 @@
       }
     },
     "@rstudio/rsconnect-ts": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@rstudio/rsconnect-ts/-/rsconnect-ts-0.7.0.tgz",
-      "integrity": "sha512-yDWUvLG1tdRqWDXF7VMWB4sv6AtOSbDlSyX9hjDNdU/JDDhxvz7zVa4f7Ton4hLZvyax5JzkhiENcuVTkSYmpg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@rstudio/rsconnect-ts/-/rsconnect-ts-0.8.0.tgz",
+      "integrity": "sha512-2J0CyTQEKySUpR2nWxr4yaBH7rV5dV2Mr4aZ9hKi7jIV2v6LySX53QHLMFaXMx+9Iir/orcJAXKIqRCUqORgVw==",
       "requires": {
         "@types/lodash": "^4.17.5",
         "@types/qs": "^6.9.15",

--- a/connect-publish/package.json
+++ b/connect-publish/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
-    "@rstudio/rsconnect-ts": "^0.7.0",
+    "@rstudio/rsconnect-ts": "^0.8.0",
     "ansi-styles": "^6.2.1"
   },
   "devDependencies": {

--- a/connect-publish/src/connect-publish.ts
+++ b/connect-publish/src/connect-publish.ts
@@ -228,7 +228,7 @@ async function publishFromDir (
       let success: Success = resp.noOp ? 'SKIP' : true
       for await (const result of poller.poll()) {
         core.debug(`received poll result: ${JSON.stringify(result)}`)
-        for (const line of result.status) {
+        for (const line of result.output) {
           if (showLogs) {
             core.info(line)
           }
@@ -245,15 +245,15 @@ async function publishFromDir (
           `id=${resp.appId}`
         ].join(' '))
 
-        const env = await envUpdater.updateAppEnvironment(resp.appId, dirName)
-        if (env.size === 0) {
+        const env = await envUpdater.updateAppEnvironment(resp.appGuid, dirName)
+        if (env.length === 0) {
           core.debug([
             'no environment variables updated for',
             `dir=${dirName}`,
             `id=${resp.appId}`
           ].join(' '))
         } else {
-          for (const key of env.keys()) {
+          for (const key of env) {
             core.debug([
               'updated environment',
               `variable=${JSON.stringify(key)}`,


### PR DESCRIPTION
I tested this change via an action in a private repository with the following configuration. All worked as expected.

```yml
name: Publish Content to Connect

on:
  push:
    branches:
      - main

jobs:
  publish:
    runs-on: ubuntu-latest
    steps:
      - name: Check out repository
        uses: actions/checkout@v4

      - name: Publish some things
        uses: rstudio/actions/connect-publish@de7ded629f69da6e6e61852baf0c9f3ed9616391
        with:
          url: ***
          api-key: ***
          access-type: logged_in
          show-logs: true
          dir: |
            ./quarto-stock-report-python
```